### PR TITLE
Install varnish(package) from varnish(yum) repo.

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,7 +7,7 @@
   when: ansible_distribution_major_version|int < 7
 
 - name: Install Varnish.
-  yum: name=varnish state=installed enablerepo=epel
+  yum: name=varnish state=installed enablerepo=varnish-4.0,epel disablerepo=*
 
 - name: Copy Varnish configuration (sysvinit).
   template:


### PR DESCRIPTION
On Amazon AMI, varnish 3.0 package is being installed from Amazon repo
due to priorities. This change forces the package to be installed from
varnish repo which is being added by this role.

epel repo is needed for other dependencies.
