### PR TITLE
fixed - Varnish installation requires gcc and more. ・ Issue #2 ・ F88/ans...

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: install packages based on package group
+  yum: name="@{{ item }}" state=present
+  with_items:
+    - Development tools
+
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 


### PR DESCRIPTION
Ensure package group "Development tools" installed.

- [Varnish installation requires gcc and more. · Issue #2 · F88/ansible-role-varnish](https://github.com/F88/ansible-role-varnish/issues/2)