### PR TITLE
Ensure package group "Development tools" installed on RedHat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
 - name: install packages based on package group
-  yum: name="@{{ item }}" state=present
+  yum: name=@{{ item }} state=present
   with_items:
-    - Development tools
+    - "Development tools"
 
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-
-- name: install packages based on package group
-  yum: name=@{{ item }} state=present
-  with_items:
-    - "Development tools"
-
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: install packages based on package group
+  yum: name="@{{ item }}" state=present
+  with_items:
+    - Development tools
+
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,9 @@
 ---
+- name: install packages based on package group
+  yum: name=@{{ item }} state=present
+  with_items:
+    - "Development tools"
+
 - name: Add Varnish repository.
   command: >
     rpm --nosignature -i https://repo.varnish-cache.org/redhat/varnish-4.0.el6.rpm


### PR DESCRIPTION
### Issues

- [Varnish installation requires gcc and more on RedHat. · Issue #2 · F88/ansible-role-varnish](https://github.com/F88/ansible-role-varnish/issues/2)

### Tests

- [Build #3 - F88/ansible-role-varnish - Travis CI](https://travis-ci.org/F88/ansible-role-varnish/builds/60208575)