### PR TITLE
Unable to install in CentOS 7

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,6 +9,25 @@
   ignore_errors: true
   when: ansible_distribution_major_version|int < 7
 
+- name: Add Varnish repository.
+  command: >
+    rpm --nosignature -i https://repo.varnish-cache.org/redhat/varnish-4.0.el7.rpm
+    creates=/var/lib/yum/repos/x86_64/7/varnish-4.0
+  ignore_errors: true
+  when: ansible_distribution_major_version|int == 7
+  
+- name: Add epel-release
+  yum:
+    name: epel-release
+    state: installed
+  when: ansible_distribution_major_version|int == 7
+  
+- name: Add redhat-rpm-config
+  yum:
+    name: redhat-rpm-config
+    state: installed
+  when: ansible_distribution_major_version|int == 7
+
 - name: Install Varnish.
   yum:
     name: varnish


### PR DESCRIPTION
I was unable to get this role to run in CentOS 7.  I don't know why the "enablerepo" value doesn't work. 

I don't know if I am just doing something wrong, but I was able to get varnish to install by adding modules for adding the repo, and installing epel-release and redhat-rpm-config manually.