### PR TITLE
Ensure the storage directory is created before starting.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,8 @@ varnish_secret: "14bac2e6-1e34-4770-8078-974373b76c90"
 varnish_config_path: /etc/varnish
 varnish_admin_listen_host: "127.0.0.1"
 varnish_admin_listen_port: "6082"
-varnish_storage: "file,/var/lib/varnish/varnish_storage.bin,256M"
+varnish_store_type: file
+varnish_store_dir: /var/lib/varnish
+varnish_store_filename: varnish_storage.bin
+varnish_store_params: "{{ varnish_store_dir }}/{{ varnish_store_filename }},256M"
+varnish_storage: "{{ varnish_store_type }},{{ varnish_store_params }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,11 @@
     mode: 0644
   notify: restart varnish
 
+- name: Create Varnish store dir
+  file:
+    path: "{{ varnish_store_dir }}"
+    state: directory
+  when: "{{ varnish_store_type }} == 'file'"
+
 - name: Ensure Varnish is started and set to run on startup.
   service: name=varnish state=started enabled=yes


### PR DESCRIPTION
If we changed the storage directory to something that didn't exist Varnish would crash at startup time.
