### PR TITLE
Copy varnish.service also on Ubuntu 16 (xenial)

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart varnish
   service: name=varnish state=restarted
+
+- name: reload systemd
+  sudo: yes
+  command: systemctl daemon-reload

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,9 @@
     group: root
     mode: 0655
   when: ansible_os_family == 'Debian' and (ansible_distribution_release == "jessie" or ansible_distribution_release == "xenial")
-  notify: restart varnish
+  notify:
+    - restart varnish
+    - reload systemd
 
 - name: Copy Varnish configuration (systemd).
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,14 +19,14 @@
     (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 7) or
     (ansible_os_family == 'Debian' and ansible_distribution_release != "xenial")
 
-- name: Copy Debian Jessie specific Varnish configs (systemd)
+- name: Copy Debian Jessie/Xenial specific Varnish configs (systemd)
   template:
     src: varnish.service.j2
     dest: "{{ varnish_systemd_config_path }}/varnish.service"
     owner: root
     group: root
     mode: 0655
-  when: ansible_os_family == 'Debian' and ansible_distribution_release == "jessie"
+  when: ansible_os_family == 'Debian' and (ansible_distribution_release == "jessie" or ansible_distribution_release == "xenial")
 
 - name: Copy Varnish configuration (systemd).
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     group: root
     mode: 0655
   when: ansible_os_family == 'Debian' and (ansible_distribution_release == "jessie" or ansible_distribution_release == "xenial")
+  notify: restart varnish
 
 - name: Copy Varnish configuration (systemd).
   template:


### PR DESCRIPTION
I upgraded my vagrant to Ubuntu 16 and noticed after provisioning that the varnish configs were not loaded correctly. After this fix they work again.