### PR TITLE
Forge the repository URL using ansible_distribution|lower variable

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,7 +5,7 @@
 
 - name: Add Varnish apt repository.
   apt_repository:
-    repo: "deb http://repo.varnish-cache.org/ubuntu {{ ansible_distribution_release }} varnish-{{ varnish_version }}"
+    repo: "deb http://repo.varnish-cache.org/{{ ansible_distribution|lower }}  {{ ansible_distribution_release }} varnish-{{ varnish_version }}"
     state: present
   when: ansible_distribution_release != "xenial"
 


### PR DESCRIPTION
It breaks the debian installation of varnish. 5 it's a good first step to have this working under debian, maybe you could add some travis tests for debian ?)