### PR TITLE
CLI support for 4.1

### DIFF
--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -99,7 +99,9 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \
+{% if varnish_version | version_compare('4.1', '<') %}
              -u varnish -g varnish \
+{% endif %}
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
 #


### PR DESCRIPTION
https://github.com/geerlingguy/ansible-role-varnish/issues/17

Seems there are some changes around users and groups for worker processes.  I'm not sure if additional changes are needed for other variables.  This change was all I needed to support 4.1
https://www.varnish-cache.org/docs/trunk/whats-new/changes.html#proactive-security-features