### PR TITLE
FIX #34: Use role variables on varnish.service template

### DIFF
--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -5,7 +5,7 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 Type=forking
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }} -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
+ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]


### PR DESCRIPTION
I update the varnish.service template, so it uses the role variables for storage and for the file paths (default.vcl and secret).

If you decided to merge this pull request (and / or the other one I made [0]), can you make a new release in Ansible Galaxy? We made a role [1], which creates a configurable VCL file using your role as a dependency to install Varnish. Meanwhile we overwrite the file in our role, but this kills the idempotency of the role. Thanks!

Best Regards,
Cristian

[0] https://github.com/geerlingguy/ansible-role-varnish/pull/33
[1] https://github.com/gcoop-libre/ansible-role-varnish