### PR TITLE
FIX #36: Add config to enable PID file for varnishd

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ The host and port through which Varnish will accept admin requests (like purge a
 
 How Varnish stores cache entries (this is passed in as the argument for `-s`). If you want to use in-memory storage, change to something like `malloc,256M`. Please read Varnish's [Getting Started guide](https://www.varnish-software.com/static/book/Getting_started.html) for more information.
 
+    varnish_pidfile: false
+    varnish_pidfile_path: /run/varnishd.pid
+
+Enables the creation of a PID file and its path, when varnishd is running.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ The host and port through which Varnish will accept admin requests (like purge a
 
 How Varnish stores cache entries (this is passed in as the argument for `-s`). If you want to use in-memory storage, change to something like `malloc,256M`. Please read Varnish's [Getting Started guide](https://www.varnish-software.com/static/book/Getting_started.html) for more information.
 
-    varnish_pidfile: false
-    varnish_pidfile_path: /run/varnishd.pid
+    varnish_pidfile: /run/varnishd.pid
 
-Enables the creation of a PID file and its path, when varnishd is running.
+Varnish PID file path. Set to an empty string if you don't want to use a PID file.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,5 +10,4 @@ varnish_config_path: /etc/varnish
 varnish_admin_listen_host: "127.0.0.1"
 varnish_admin_listen_port: "6082"
 varnish_storage: "file,/var/lib/varnish/varnish_storage.bin,256M"
-varnish_pidfile: false
-varnish_pidfile_path: /run/varnishd.pid
+varnish_pidfile: /run/varnishd.pid

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ varnish_config_path: /etc/varnish
 varnish_admin_listen_host: "127.0.0.1"
 varnish_admin_listen_port: "6082"
 varnish_storage: "file,/var/lib/varnish/varnish_storage.bin,256M"
+varnish_pidfile: false
+varnish_pidfile_path: /run/varnishd.pid

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -97,7 +97,7 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
 {% if varnish_pidfile %}
-             -P {{ varnish_pidfile_path }} \
+             -P {{ varnish_pidfile }} \
 {% endif %}
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -96,6 +96,9 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
+{% if varnish_pidfile %}
+             -P {{ varnish_pidfile_path }} \
+{% endif %}
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -3,9 +3,12 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 
 [Service]
 Type=forking
+{% if varnish_pidfile %}
+PIDFile={{ varnish_pidfile_path }}
+{% endif %}
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
+ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile_path }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -5,7 +5,7 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 Type=forking
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }} -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
+ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -4,11 +4,11 @@ Description=Varnish Cache, a high-performance HTTP accelerator
 [Service]
 Type=forking
 {% if varnish_pidfile %}
-PIDFile={{ varnish_pidfile_path }}
+PIDFile={{ varnish_pidfile }}
 {% endif %}
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile_path }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
+ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]


### PR DESCRIPTION
This commit add two variables **varnish_pidfile** and **varnish_pidfile_path** to enable the use of a PID file and to define its path.

It also modifies two templates, adding the options to SysV and systemd start scripts.

This pull request includes the commit of my previous [Pull Request](https://github.com/geerlingguy/ansible-role-varnish/pull/35), because both modifies the template **templates/varnish.service.j2**.


