### PR TITLE
Fixes #39: Varnish 5 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 varnish_package_name: "varnish"
-varnish_version: "4.1"
+varnish_version: "5.0.0"
 
 varnish_use_default_vcl: true
 varnish_default_vcl_template_path: default.vcl.j2

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,19 +6,7 @@
     - libedit-devel
     - initscripts
 
-- name: Add Varnish repository.
+- name: Install Varnish from package.
   yum:
-    name: https://repo.varnish-cache.org/redhat/varnish-{{ varnish_version }}.el6.rpm
+    name: https://repo.varnish-cache.org/pkg/{{ varnish_version }}/varnish-{{ varnish_version }}-1.el{{ ansible_distribution_version.split(".")[0] }}.{{ ansible_architecture }}.rpm
     state: present
-  when: ansible_distribution_major_version|int < 7
-
-- name: Set repo fact appropriately.
-  set_fact:
-    varnish_yum_enablerepo: "{{ 'varnish-{{ varnish_version }},epel' if (ansible_distribution_major_version|int < 7) else 'epel' }}"
-
-- name: Install Varnish.
-  yum:
-    name: "{{ varnish_package_name }}"
-    state: installed
-    enablerepo: "{{ varnish_yum_enablerepo }}"
-    disablerepo: "*"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -20,10 +20,5 @@
         - logrotate
       when: ansible_os_family == 'RedHat' and ansible_distribution_major_version < '7'
 
-    - name: Force working version of Varnish on Ubuntu 14.04.
-      set_fact:
-        varnish_version: "4.0"
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
-
   roles:
     - role_under_test


### PR DESCRIPTION
This PR adds Varnish 5.0.0 support. Still to do: keep supporting 3.x and 4.x for now (will need to add back in the old RH/Deb tasks and have `when` conditions based on the major version that's set...

See related: https://github.com/geerlingguy/ansible-role-varnish/issues/39

Also, regarding the Ubuntu 14.04 build failure—that seems to be an upstream issue with Varnish >= 4.1.x; see https://github.com/geerlingguy/ansible-role-varnish/issues/40
