### PR TITLE
allow varnishlog and varnishncsa service state to be configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,7 @@ varnish_admin_listen_port: "6082"
 
 varnish_storage: "file,/var/lib/varnish/varnish_storage.bin,256M"
 varnish_pidfile: /run/varnishd.pid
+
+# Which services to run
+varnish_use_varnishlog: true
+varnish_use_varnishncsa: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,3 +70,9 @@
 
 - name: Ensure Varnish is started and set to run on startup.
   service: name=varnish state=started enabled=yes
+
+- name: Ensure the varnishlog service is in the correct state
+  service: name=varnishlog state={{ varnish_use_varnishlog | ternary('started', 'stopped') }} enabled={{ varnish_use_varnishlog | ternary(True, False) }}
+
+- name: Ensure the varnishcnsa service is in the correct state
+  service: name=varnishncsa state={{ varnish_use_varnishncsa | ternary('started', 'stopped') }} enabled={{ varnish_use_varnishncsa | ternary(True, False) }}


### PR DESCRIPTION
By default the packages seem to be enable them.
