### PR TITLE
Add missing "redhat-rpm-config" packege to installed packages

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,6 +5,7 @@
     - gcc
     - libedit-devel
     - initscripts
+    - redhat-rpm-config
 
 - name: Add Varnish repository.
   yum:


### PR DESCRIPTION
If I try to install this role on Centos 7 I get a following error:

```
TASK [geerlingguy.varnish : Install Varnish.] **********************************
fatal: [192.168.104.11]: FAILED! => {"changed": true, "failed": true, "msg": "Error: Package: varnish-4.0.3-3.el7.x86_64 (epel)\n           Requires: redhat-rpm-config\n", "rc": 1, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * epel: epel.mirror.angkasa.id\nResolving Dependencies\n--> Running transaction check\n---> Package varnish.x86_64 0:4.0.3-3.el7 will be installed\n--> Processing Dependency: varnish-libs(x86-64) = 4.0.3-3.el7 for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: redhat-rpm-config for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishapi.so.1(LIBVARNISHAPI_1.3)(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishapi.so.1(LIBVARNISHAPI_1.2)(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishapi.so.1(LIBVARNISHAPI_1.1)(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishapi.so.1(LIBVARNISHAPI_1.0)(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: jemalloc for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvgz.so()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvcc.so()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishcompat.so()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnishapi.so.1()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libvarnish.so()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Processing Dependency: libjemalloc.so.1()(64bit) for package: varnish-4.0.3-3.el7.x86_64\n--> Running transaction check\n---> Package jemalloc.x86_64 0:3.6.0-1.el7 will be installed\n---> Package varnish.x86_64 0:4.0.3-3.el7 will be installed\n--> Processing Dependency: redhat-rpm-config for package: varnish-4.0.3-3.el7.x86_64\n---> Package varnish-libs.x86_64 0:4.0.3-3.el7 will be installed\n--> Finished Dependency Resolution\n You could try using --skip-broken to work around the problem\n You could try running: rpm -Va --nofiles --nodigest\n"]}
```