### PR TITLE
Fix varnish repo id on CentOS 6

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,9 +12,13 @@
     state: present
   when: ansible_distribution_major_version|int < 7
 
+- name: Set a string for the varnish repository identifier.
+  set_fact:
+    varnish_yum_repo: "varnish-{{ varnish_version }},epel"
+
 - name: Set repo fact appropriately.
   set_fact:
-    varnish_yum_enablerepo: "{{ 'varnish-{{ varnish_version }},epel' if (ansible_distribution_major_version|int < 7) else 'epel' }}"
+    varnish_yum_enablerepo: "{{ varnish_yum_repo if (ansible_distribution_major_version|int < 7) else 'epel' }}"
 
 - name: Install Varnish.
   yum:


### PR DESCRIPTION
Fixes use of Jinja2 string concatenation by setting an extra fact to represent the repository identifier. Alternative would be to use an array of strings with the [join](http://jinja.pocoo.org/docs/2.9/templates/#join) filter.