### PR TITLE
Use PIDFILE instead of -P parameter in init script.

### DIFF
--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -27,6 +27,11 @@ NPROCS="unlimited"
 # use Alternative 3, Advanced configuration, below
 RELOAD_VCL=1
 
+{% if varnish_pidfile %}
+# Varnish PID file
+PIDFILE="{{ varnish_pidfile }}"
+{% endif %}
+
 # This file contains 4 alternatives, please use only one.
 
 ## Alternative 1, Minimal configuration, no VCL
@@ -96,9 +101,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
-{% if varnish_pidfile %}
-             -P {{ varnish_pidfile }} \
-{% endif %}
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \


### PR DESCRIPTION
This fixes: https://github.com/geerlingguy/ansible-role-varnish/issues/53

setting `-P $pidfile` in /etc/default/varnish is not supported, see https://github.com/varnishcache/pkg-varnish-cache/issues/72. The intended way is to set `$PIDFILE` which is automatically sourced in /etc/init.d/varnish.