### PR TITLE
Add different vhosts and different backends from playbook variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ We can setup vhost with different backend as following
         backend: zabbix
 
 
-
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ We can setup vhost with different backend as following
         host: 10.0.2.3
         port: 80
     varnish_vhost:
-      mywebsite.fr:
+      example.com:
         backend: webhosting
-      supervision.mywebsite.fr:
+      supervisor.example.com:
         backend: zabbix
 
+`varnish_backend` is defining varnish backend in addition of default backend. We need to provide a name, a host value and a port value. We can define multiple backend but is not mandatory.
+`varnish_vhost` is getting a FQDN without www (it will be added automatically) and a backend value. We can use multiple times the same backend. If you want to use default backend, use backend `default`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ Varnish PID file path. Set to an empty string if you don't want to use a PID fil
 
 Services that will be started at boot and should be running after this role is complete. You might need to add additional services if required, e.g. `varnishncsa` and `varnishlog`. If set to an empty array, no services will be enabled at startup.
 
+We can setup vhost with different backend as following
+
+    varnish_backend:
+      webhosting:
+        host: 10.0.2.1
+        port: 80
+      zabbix:
+        host: 10.0.2.3
+        port: 80
+    varnish_vhost:
+      mywebsite.fr:
+        backend: webhosting
+      supervision.mywebsite.fr:
+        backend: zabbix
+
+
+
 ## Dependencies
 
 None.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,28 @@
   when: varnish_use_default_vcl
   notify: restart varnish
 
+- name: setup each backend
+  lineinfile:
+    dest: "{{ varnish_config_path }}/default.vcl"
+    insertbefore: "sub vcl_recv {"
+    line: "backend {{item.key}} {\n
+    .host = \"{{ item.value.host }}\";\n
+    .port = \"{{ item.value.port }}\";\n}"
+  when: ( varnish_backend is defined and varnish_backend )
+  notify: restart varnish
+  with_dict: "{{ varnish_backend }}"
+
+- name: setup each vhost
+  lineinfile:
+    dest: "{{ varnish_config_path }}/default.vcl"
+    insertafter: "sub vcl_recv {"
+    line: "  if (req.http.host == \"{{ item.key }}\" || req.http.host == \"www.{{ item.key}}\") {\n
+   set req.backend_hint = {{ item.value.backend }};\n
+    }"
+  with_dict: "{{ varnish_vhost }}"
+  when: ( varnish_vhost is defined and varnish_vhost )
+  notify: restart varnish
+
 - name: Copy varnish secret.
   template:
     src: secret.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,28 +59,6 @@
   when: varnish_use_default_vcl
   notify: restart varnish
 
-- name: setup each backend
-  lineinfile:
-    dest: "{{ varnish_config_path }}/default.vcl"
-    insertbefore: "sub vcl_recv {"
-    line: "backend {{item.key}} {\n
-    .host = \"{{ item.value.host }}\";\n
-    .port = \"{{ item.value.port }}\";\n}"
-  when: ( varnish_backend is defined and varnish_backend )
-  notify: restart varnish
-  with_dict: "{{ varnish_backend }}"
-
-- name: setup each vhost
-  lineinfile:
-    dest: "{{ varnish_config_path }}/default.vcl"
-    insertafter: "sub vcl_recv {"
-    line: "  if (req.http.host == \"{{ item.key }}\" || req.http.host == \"www.{{ item.key}}\") {\n
-   set req.backend_hint = {{ item.value.backend }};\n
-    }"
-  with_dict: "{{ varnish_vhost }}"
-  when: ( varnish_vhost is defined and varnish_vhost )
-  notify: restart varnish
-
 - name: Copy varnish secret.
   template:
     src: secret.j2

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -9,3 +9,6 @@ backend default {
   .host = "{{ varnish_default_backend_host }}";
   .port = "{{ varnish_default_backend_port }}";
 }
+
+sub vcl_recv {
+}

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -20,8 +20,7 @@ backend {{ backend }} {
 {% endif %}
 
 sub vcl_recv {
-
-{% if varnish_backend is defined %}
+{% if varnish_vhost is defined %}
 {% for vhost, value in varnish_vhost.iteritems() if varnish_vhost is defined %}
   {% if loop.first %}
   if (req.http.host == "{{ vhost }}" || req.http.host == "www.{{ vhost }}") {

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -10,5 +10,26 @@ backend default {
   .port = "{{ varnish_default_backend_port }}";
 }
 
+{% if varnish_backend is defined %}
+{% for backend, value in varnish_backend.iteritems() %}
+backend {{ backend }} {
+  .host = "{{ value.host }}";
+  .port = "{{ value.port }}";
+}
+{% endfor %}
+{% endif %}
+
 sub vcl_recv {
+
+{% if varnish_backend is defined %}
+{% for vhost, value in varnish_vhost.iteritems() if varnish_vhost is defined %}
+  {% if loop.first %}
+  if (req.http.host == "{{ vhost }}" || req.http.host == "www.{{ vhost }}") {
+  {% else %}
+  elseif (req.http.host == "{{ vhost }}" || req.http.host == "www.{{ vhost }}") {
+  {% endif %}
+    set req.backend_hint = {{ value.backend }};
+  }
+{% endfor %}
+{% endif %}
 }


### PR DESCRIPTION
Add capabality to setup different vhosts and different backends from a
playbook variable and not from a specific template. Choose the backend
in depend of fqnd of vhost.

Tested on Debian 8.6 with and without the 2 variables

Signed-off-by: Cyril Lopez <cylopez@redhat.com>