### PR TITLE
Support Varnish 5+ for Debian/Ubuntu, and PROXY protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ Whether to use the included (simplistic) default Varnish VCL, using the backend 
 
 The default VCL file to be copied (if `varnish_use_default_vcl` is `true`). Defaults the the simple template inside `templates/default.vcl.j2`. This path should be relative to the directory from which you run your playbook.
 
-    varnish_listen_port: "80"
+    varnish_listen_ports:
+        - port: 80
+          # proxy_proto: yes
 
-The port on which Varnish will listen (typically port 80).
+The ports on which Varnish will listen (typically port 80). If Varnish needs to expect a [PROXY protocol](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) connection, then set `proxy_proto` to `yes`.
 
     varnish_default_backend_host: "127.0.0.1"
     varnish_default_backend_port: "8080"
+    # varnish_default_backend_proxy_proto: 1
 
-Some settings for the default "default.vcl" template that will be copied to the `varnish_config_path` folder. The default backend host/port could be Apache or Nginx (or some other HTTP server) running on the same host or some other host (in which case, you might use port 80 instead).
+Some settings for the default "default.vcl" template that will be copied to the `varnish_config_path` folder. The default backend host/port could be Apache or Nginx (or some other HTTP server) running on the same host or some other host (in which case, you might use port 80 instead). If the backend server is expecting a PROXY protocol connection, then set the variable to `1`.
 
     varnish_limit_nofile: 131072
 
@@ -71,6 +74,7 @@ Services that will be started at boot and should be running after this role is c
       apache:
         host: 10.0.2.2
         port: 80
+        # proxy_proto: 1
       nodejs:
         host: 10.0.2.3
         port: 80

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 varnish_package_name: "varnish"
 varnish_version: "4.1"
+# Varnish 5+ is currently only supported on Debian and Ubuntu.
+# varnish_version: "5.1"
 
 varnish_use_default_vcl: true
 varnish_default_vcl_template_path: default.vcl.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,8 +9,15 @@ varnish_default_vcl_template_path: default.vcl.j2
 
 varnish_default_backend_host: "127.0.0.1"
 varnish_default_backend_port: "8080"
+# If backend server expect PROXY protocol connexion:
+# varnish_default_backend_proxy_proto: 1
 
-varnish_listen_port: "80"
+varnish_listen_ports:
+  - port: 80
+  - port: 6081
+    # If Varnish must expect a PROXY protocol connexion:
+    proxy_proto: yes
+
 varnish_secret: "14bac2e6-1e34-4770-8078-974373b76c90"
 varnish_config_path: /etc/varnish
 varnish_limit_nofile: 131072
@@ -29,6 +36,7 @@ varnish_enabled_services:
 #   apache:
 #     host: 10.0.2.2
 #     port: 80
+#     proxy_proto: 1
 #   nodejs:
 #     host: 10.0.2.3
 #     port: 80

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,11 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Ensure Varnish config path exists.
+  file:
+    path: "{{ varnish_config_path }}"
+    state: directory
+
 - name: Copy Varnish configuration (sysvinit).
   template:
     src: varnish.j2
@@ -43,11 +48,6 @@
   when: >
     (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int >= 7) or
     (ansible_os_family == 'Debian' and ansible_distribution_release == "xenial")
-
-- name: Ensure Varnish config path exists.
-  file:
-    path: "{{ varnish_config_path }}"
-    state: directory
 
 - name: Copy Varnish default VCL.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Copy Varnish configuration (systemd).
   template:
     src: varnish.params.j2
-    dest: /etc/varnish/varnish.params
+    dest: "{{ varnish_config_path }}/varnish.params"
     owner: root
     group: root
     mode: 0644

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,19 +3,32 @@
   apt:
     name: apt-transport-https
     state: installed
-  when: ansible_distribution_release != "xenial"
 
-- name: Add Varnish apt key.
+# For Varnish up to 4.x
+- name: Add varnish-cache.org apt key.
   apt_key:
     url: https://repo.varnish-cache.org/GPG-key.txt
     state: present
-  when: ansible_distribution_release != "xenial"
+  when: ansible_distribution_release != "xenial" and varnish_version|int < 5
 
 - name: Add Varnish apt repository.
   apt_repository:
     repo: "deb https://repo.varnish-cache.org/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} varnish-{{ varnish_version }}"
     state: present
-  when: ansible_distribution_release != "xenial"
+  when: ansible_distribution_release != "xenial" and varnish_version|int < 5
+
+# For Varnish 5+
+- name: Add packagecloud.io apt key.
+  apt_key:
+    url: https://packagecloud.io/varnishcache/varnish5/gpgkey
+    state: present
+  when: varnish_version|int >= 5
+
+- name: Add Varnish 5+ apt repository.
+  apt_repository:
+    repo: "deb https://packagecloud.io/varnishcache/varnish5/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main"
+    state: present
+  when: varnish_version|int >= 5
 
 - name: Install Varnish.
   apt:

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -8,7 +8,7 @@ vcl 4.0;
 backend default {
   .host = "{{ varnish_default_backend_host }}";
   .port = "{{ varnish_default_backend_port }}";
-{% if varnish_default_backend_proxy_proto is defined %}
+{% if varnish_default_backend_proxy_proto is defined and varnish_version|float >= 4.1 %}
   .proxy_header = {{ varnish_default_backend_proxy_proto }};
 {% endif %}
 }
@@ -19,7 +19,7 @@ backend default {
 backend {{ backend }} {
   .host = "{{ value.host }}";
   .port = "{{ value.port }}";
-{% if value.proxy_proto is defined %}
+{% if value.proxy_proto is defined and varnish_version|float >= 4.1 %}
   .proxy_header = {{ value.proxy_proto }};
 {% endif %}
 }

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -8,6 +8,9 @@ vcl 4.0;
 backend default {
   .host = "{{ varnish_default_backend_host }}";
   .port = "{{ varnish_default_backend_port }}";
+{% if varnish_default_backend_proxy_proto is defined %}
+  .proxy_header = {{ varnish_default_backend_proxy_proto }};
+{% endif %}
 }
 
 {% if varnish_backends is defined %}
@@ -16,6 +19,9 @@ backend default {
 backend {{ backend }} {
   .host = "{{ value.host }}";
   .port = "{{ value.port }}";
+{% if value.proxy_proto is defined %}
+  .proxy_header = {{ value.proxy_proto }};
+{% endif %}
 }
 {% endfor %}
 {% endif %}

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -91,7 +91,7 @@ VARNISH_TTL=120
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-DAEMON_OPTS="{% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto %},PROXY{% endif %} \
+DAEMON_OPTS="{% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto and varnish_version|float >= 4.1 %},PROXY{% endif %} \
 {% endfor %}
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -67,12 +67,6 @@ PIDFILE="{{ varnish_pidfile }}"
 # # Main configuration file. You probably want to change it :)
 VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 #
-# # Default address and port to bind to
-# # Blank address means all IPv4 and IPv6 interfaces, otherwise specify
-# # a host name, an IPv4 dotted quad, or an IPv6 address in brackets.
-# VARNISH_LISTEN_ADDRESS=
-VARNISH_LISTEN_PORT={{ varnish_listen_port }}
-#
 # # Telnet admin interface listen address and port
 VARNISH_ADMIN_LISTEN_ADDRESS={{ varnish_admin_listen_host }}
 VARNISH_ADMIN_LISTEN_PORT={{ varnish_admin_listen_port }}
@@ -97,7 +91,8 @@ VARNISH_TTL=120
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
+DAEMON_OPTS="{% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto %},PROXY{% endif %} \
+{% endfor %}
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \

--- a/templates/varnish.params.j2
+++ b/templates/varnish.params.j2
@@ -11,7 +11,7 @@ VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 # and IPv6 interfaces, otherwise specify a host name, an IPv4 dotted
 # quad, or an IPv6 address in brackets.
 # VARNISH_LISTEN_ADDRESS=192.168.1.5
-VARNISH_LISTEN_PORT={{ varnish_listen_port }}
+VARNISH_LISTEN_PORT={{ varnish_listen_ports[0].port }}
 
 # Admin interface listen address and port
 VARNISH_ADMIN_LISTEN_ADDRESS={{ varnish_admin_listen_host }}

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -8,7 +8,7 @@ PIDFile={{ varnish_pidfile }}
 {% endif %}
 LimitNOFILE={{ varnish_limit_nofile }}
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
+ExecStart=/usr/sbin/varnishd {% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto %},PROXY{% endif %} {% endfor %}-T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -8,7 +8,7 @@ PIDFile={{ varnish_pidfile }}
 {% endif %}
 LimitNOFILE={{ varnish_limit_nofile }}
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd {% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto %},PROXY{% endif %} {% endfor %}-T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
+ExecStart=/usr/sbin/varnishd {% for p in varnish_listen_ports %}-a :{{ p.port }}{% if p.proxy_proto is defined and p.proxy_proto and varnish_version|float >= 4.1 %},PROXY{% endif %} {% endfor %}-T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,8 @@
 - hosts: all
 
+  vars:
+    # varnish_version: 5.1
+
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
@@ -27,3 +30,14 @@
 
   roles:
     - role_under_test
+
+  post_tasks:
+    - name: Get Varnish version
+      command: varnishd -V
+      register: varnish_version
+      changed_when: no
+
+    - name: Show Varnish version
+      debug:
+        var: varnish_version
+      changed_when: no


### PR DESCRIPTION
Support Varnish 5+ from packagecloud.io for Debian/Ubuntu (but not RHEL), which should (partly) address #39.

As a side fixes:
- The config path /etc/varnish was hardcoded; and
- It's existence check was done after a task pushing varnish.params file into.