### PR TITLE
PROXY protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,18 @@ Whether to use the included (simplistic) default Varnish VCL, using the backend 
 
 The default VCL file to be copied (if `varnish_use_default_vcl` is `true`). Defaults the the simple template inside `templates/default.vcl.j2`. This path should be relative to the directory from which you run your playbook.
 
-    varnish_listen_port: "80"
+    varnish_listen:
+        - port: 80
+          # address: 127.0.0.1
+          # proxy_proto: yes
 
-The port on which Varnish will listen (typically port 80).
+The addresses and ports on which Varnish will listen (typically, all addresses on port 80). If Varnish needs to expect a [PROXY protocol](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) connection, then set `proxy_proto` to `yes`.
 
     varnish_default_backend_host: "127.0.0.1"
     varnish_default_backend_port: "8080"
+    # varnish_default_backend_proxy_proto: 1
 
-Some settings for the default "default.vcl" template that will be copied to the `varnish_config_path` folder. The default backend host/port could be Apache or Nginx (or some other HTTP server) running on the same host or some other host (in which case, you might use port 80 instead).
+Some settings for the default "default.vcl" template that will be copied to the `varnish_config_path` folder. The default backend host/port could be Apache or Nginx (or some other HTTP server) running on the same host or some other host (in which case, you might use port 80 instead). If the backend server is expecting a PROXY protocol connection, then set the variable to `1`.
 
     varnish_limit_nofile: 131072
 
@@ -71,6 +75,7 @@ Services that will be started at boot and should be running after this role is c
       apache:
         host: 10.0.2.2
         port: 80
+        # proxy_proto: 1
       nodejs:
         host: 10.0.2.3
         port: 80

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,16 @@ varnish_default_vcl_template_path: default.vcl.j2
 
 varnish_default_backend_host: "127.0.0.1"
 varnish_default_backend_port: "8080"
+# If backend server expect PROXY protocol connexion:
+# varnish_default_backend_proxy_proto: 1
 
-varnish_listen_port: "80"
+varnish_listen:
+  - port: 80
+  # - address: 127.0.0.1
+  #   port: 6081
+  #   # If Varnish must expect a PROXY protocol connexion:
+  #   proxy_proto: yes
+
 varnish_secret: "14bac2e6-1e34-4770-8078-974373b76c90"
 varnish_config_path: /etc/varnish
 varnish_limit_nofile: 131072
@@ -27,6 +35,7 @@ varnish_enabled_services:
 #   apache:
 #     host: 10.0.2.2
 #     port: 80
+#     proxy_proto: 1
 #   nodejs:
 #     host: 10.0.2.3
 #     port: 80

--- a/templates/default.vcl.j2
+++ b/templates/default.vcl.j2
@@ -8,6 +8,9 @@ vcl 4.0;
 backend default {
   .host = "{{ varnish_default_backend_host }}";
   .port = "{{ varnish_default_backend_port }}";
+{% if varnish_default_backend_proxy_proto is defined and varnish_version|float >= 4.1 %}
+  .proxy_header = {{ varnish_default_backend_proxy_proto }};
+{% endif %}
 }
 
 {% if varnish_backends is defined %}
@@ -16,6 +19,9 @@ backend default {
 backend {{ backend }} {
   .host = "{{ value.host }}";
   .port = "{{ value.port }}";
+{% if value.proxy_proto is defined and varnish_version|float >= 4.1 %}
+  .proxy_header = {{ value.proxy_proto }};
+{% endif %}
 }
 {% endfor %}
 {% endif %}

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -71,7 +71,7 @@ VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 # # Blank address means all IPv4 and IPv6 interfaces, otherwise specify
 # # a host name, an IPv4 dotted quad, or an IPv6 address in brackets.
 # VARNISH_LISTEN_ADDRESS=
-VARNISH_LISTEN_PORT={{ varnish_listen_port }}
+# VARNISH_LISTEN_PORT=
 #
 # # Telnet admin interface listen address and port
 VARNISH_ADMIN_LISTEN_ADDRESS={{ varnish_admin_listen_host }}
@@ -97,7 +97,8 @@ VARNISH_TTL=120
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
+DAEMON_OPTS="{% for l in varnish_listen %}-a {%if l.address is defined and l.address %}{{ l.address }}{% endif %}:{{ l.port }}{% if l.proxy_proto is defined and l.proxy_proto and varnish_version|float >= 4.1 %},PROXY{% endif %} \
+{% endfor %}
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \

--- a/templates/varnish.params.j2
+++ b/templates/varnish.params.j2
@@ -11,7 +11,7 @@ VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 # and IPv6 interfaces, otherwise specify a host name, an IPv4 dotted
 # quad, or an IPv6 address in brackets.
 # VARNISH_LISTEN_ADDRESS=192.168.1.5
-VARNISH_LISTEN_PORT={{ varnish_listen_port }}
+VARNISH_LISTEN_PORT={{ varnish_listen[0].port }}
 
 # Admin interface listen address and port
 VARNISH_ADMIN_LISTEN_ADDRESS={{ varnish_admin_listen_host }}

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -8,7 +8,7 @@ PIDFile={{ varnish_pidfile }}
 {% endif %}
 LimitNOFILE={{ varnish_limit_nofile }}
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
+ExecStart=/usr/sbin/varnishd {% for l in varnish_listen %}-a {%if l.address is defined and l.address %}{{ l.address }}{% endif %}:{{ l.port }}{% if l.proxy_proto is defined and l.proxy_proto and varnish_version|float >= 4.1 %},PROXY{% endif %} {% endfor %}-T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]


### PR DESCRIPTION
Tested working with debian9 debian8 ubuntu1604 and centos7.

(Note that fedora24 has a logrotate problem not related to these changes:
```
TASK [Ensure build dependencies are installed (RedHat < 7).] *******************
failed: [localhost] (item=[u'logrotate']) => {"failed": true, "item": ["logrotate"], "msg": "python2 yum module is needed for this  module"}
```