### PR TITLE
Resolve an issue with the systemd/sysvinit ansible conflict

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,6 +91,6 @@
     enabled: yes
     use: "service"
   with_items: "{{ varnish_enabled_services | default([]) }}"
-  when: >
-    varnish_enabled_services and
-    (ansible_os_family == 'Debian' and ansible_distribution_release == "xenial")
+  when:
+    - varnish_enabled_services
+    - (ansible_os_family == 'Debian' and ansible_distribution_release == "xenial")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,6 @@
     name: "{{ item }}"
     state: started
     enabled: yes
-    use: "service"
   with_items: "{{ varnish_enabled_services | default([]) }}"
   when: >
     varnish_enabled_services and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,5 +77,20 @@
     name: "{{ item }}"
     state: started
     enabled: yes
+    use: "service"
   with_items: "{{ varnish_enabled_services | default([]) }}"
-  when: varnish_enabled_services
+  when: >
+    varnish_enabled_services and
+    (ansible_os_family != 'Debian' and ansible_distribution_release != "xenial")
+
+# See: https://github.com/ansible/ansible/issues/22303
+- name: Ensure Varnish services are started enabled on startup (Xenial specific)
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+    use: "service"
+  with_items: "{{ varnish_enabled_services | default([]) }}"
+  when: >
+    varnish_enabled_services and
+    (ansible_os_family == 'Debian' and ansible_distribution_release == "xenial")


### PR DESCRIPTION
Currently, there appears to be an issue with Ansible in which, if a
service is already enabled with sysvinit, the service will not be
enabled with Ansible. This appears to be the condition with this
repository; likely, the upstream package is bringing in the sysvinit
script (as it's not being deployed by ansible) and enabling it.

This commit implements a workaround as documented
https://github.com/ansible/ansible-modules-core/issues/3764#issuecomment-284331673.
While, confusingly, the package is "using" the sysvinit style service
tool for enabling the service, systemd implements a compatibility layer
that allows enabling it via this shim. This correctly enables the
service.

See https://github.com/ansible/ansible/issues/22303
See https://github.com/geerlingguy/ansible-role-php/commit/84ab337202415dbf2fe694f156128f721b502a84