### PR TITLE
Add varnish listen_address variable (Fixed version of #24 and #60)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ varnish_default_vcl_template_path: default.vcl.j2
 varnish_default_backend_host: "127.0.0.1"
 varnish_default_backend_port: "8080"
 
+varnish_listen_address: ""
 varnish_listen_port: "80"
 varnish_secret: "14bac2e6-1e34-4770-8078-974373b76c90"
 varnish_config_path: /etc/varnish

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   when: >
     (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 7) or
     (ansible_os_family == 'Debian' and ansible_distribution_release != "xenial")
+  notify: restart varnish
 
 - name: Copy Debian Jessie/Xenial specific Varnish configs (systemd).
   template:

--- a/templates/varnish.j2
+++ b/templates/varnish.j2
@@ -70,7 +70,7 @@ VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 # # Default address and port to bind to
 # # Blank address means all IPv4 and IPv6 interfaces, otherwise specify
 # # a host name, an IPv4 dotted quad, or an IPv6 address in brackets.
-# VARNISH_LISTEN_ADDRESS=
+VARNISH_LISTEN_ADDRESS={{ varnish_listen_address }}
 VARNISH_LISTEN_PORT={{ varnish_listen_port }}
 #
 # # Telnet admin interface listen address and port

--- a/templates/varnish.params.j2
+++ b/templates/varnish.params.j2
@@ -10,7 +10,7 @@ VARNISH_VCL_CONF={{ varnish_config_path }}/default.vcl
 # Default address and port to bind to. Blank address means all IPv4
 # and IPv6 interfaces, otherwise specify a host name, an IPv4 dotted
 # quad, or an IPv6 address in brackets.
-# VARNISH_LISTEN_ADDRESS=192.168.1.5
+VARNISH_LISTEN_ADDRESS={{ varnish_listen_address }}
 VARNISH_LISTEN_PORT={{ varnish_listen_port }}
 
 # Admin interface listen address and port

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -25,7 +25,7 @@ TasksMax=infinity
 # Maximum size of the corefile.
 LimitCORE=infinity
 
-ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }} {{ varnishd_extra_options }}
+ExecStart=/usr/sbin/varnishd -a {{ varnish_listen_address }}:{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }} {{ varnishd_extra_options }}
 ExecReload=/usr/sbin/varnishreload
 
 Restart=on-failure


### PR DESCRIPTION
See #60 and #24 for history. 

This is simply a fixed version of the previous pull request that (should) pass the tests. It adds the ability to specify varnish's listen address.