### PR TITLE
Fix/package version update

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,7 +16,7 @@
 
 - name: Ensure Varnish is installed.
   apt:
-    name: "{{ varnish_package_name ~ '=' ~ varnish_version ~ '*' }}"
+    name: "{{ varnish_package_name ~ '=' ~ varnish_version ~ '.*' }}"
     state: present
     update_cache: yes
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,8 +16,9 @@
 
 - name: Ensure Varnish is installed.
   apt:
-    name: "{{ varnish_package_name }}"
+    name: "{{ varnish_package_name ~ '=' ~ varnish_version ~ '*' }}"
     state: present
+    update_cache: yes
 
 - name: Ensure old role-managed Varnish systemd unit file is removed.
   file:


### PR DESCRIPTION
With the apt module, added the capability to update a package, specifying the version within a release.

EG: varnish_version: 4.1

-> will run 4.1.*

This ensure package upgrade within time.
It seems not working the same way with Yum.