### PR TITLE
Update LimitMEMLOCK for Systemd

### DIFF
--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -7,7 +7,7 @@ Type=forking
 PIDFile={{ varnish_pidfile }}
 {% endif %}
 LimitNOFILE={{ varnish_limit_nofile }}
-LimitMEMLOCK=82000
+LimitMEMLOCK=85983232
 ExecStart=/usr/sbin/varnishd -a :{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }}
 ExecReload=/usr/share/varnish/reload-vcl
 


### PR DESCRIPTION
I recently compare the template of the systemd service file against the one installed from the _packagecloud.io_ repos, and the **LimitMEMLOCK** value differ.

The commit just update this value.