### PR TITLE
fix default yum repo priority on AMZN Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,9 @@ varnishd_extra_options: ""
 varnish_enabled_services:
   - varnish
 
+# make sure our repo gets used; set highest priority for yum_repository module:
+varnish_packagecloud_repo_yum_repository_priority: "1"
+
 # Optionally define additional backends.
 # varnish_backends:
 #   apache:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -16,6 +16,7 @@
     gpgkey: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
     sslverify: 1
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    priority: "{{ varnish_packagecloud_repo_yum_repository_priority }}"
   register: varnish_packagecloud_repo_addition
 
 - name: Refresh yum metadata cache if repo changed.


### PR DESCRIPTION
## What's changing:

Set a priority when adding the yum repo that is a lower number (closer to `1`) than the CentOS/Amazon linux default. [1]

## Why:

On Amazon Linux 1, (and likely on CentOS)
the vendor's repo, at `/etc/yum.repos.d/amzn-main.repo` has relevant content:
```
[amzn-main]
priority=10
```

The ansible yum repository module we use has a default of `priority=99`. [2]

The net outcome is: `yum` will always select the vendor's repo (which contains v3.x), and never uses the repo added by this ansible role.

[1] https://wiki.centos.org/PackageManagement/Yum/Priorities#head-6f52124e909c1691eb0c501ba38ae9202b66d6da
[2] https://docs.ansible.com/ansible/2.5/modules/yum_repository_module.html