### PR TITLE
Allows to not use packagecloud.io as package repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Varnish package name you want to install. See `apt-cache policy varnish` or `yum
 
 Varnish version that should be installed. See the [Varnish Cache packagecloud.io repositories](https://packagecloud.io/varnishcache) for a listing of available versions. Some examples include: `5.1`, `5.0`, `4.1`, `4.0`, `3.0`, and `2.1`.
 
+	 varnish_use_packagecloud: false
+	 
+If, for any reason, you don't want to use [packagecloud.io](https://packagecloud.io/varnishcache) as packages repository you can set `varnish_use_packagecloud ` to `false` (default value is `true`). This could be useful if the package for the version/distro you need isn't present on [packagecloud.io](https://packagecloud.io/varnishcache) but it is present on the default repositories.
+
     varnish_config_path: /etc/varnish
 
 The path in which Varnish configuration files will be stored.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 varnish_package_name: "varnish"
+varnish_use_packagecloud: true
 varnish_version: "5.1"
 
 varnish_use_default_vcl: true

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,11 +8,13 @@
   apt_key:
     url: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
     state: present
+  when: varnish_use_packagecloud
 
 - name: Add packagecloud.io Varnish apt repository.
   apt_repository:
     repo: "deb https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main"
     state: present
+  when: varnish_use_packagecloud
 
 - name: Ensure Varnish is installed.
   apt:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -18,6 +18,7 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     priority: "{{ varnish_packagecloud_repo_yum_repository_priority }}"
   register: varnish_packagecloud_repo_addition
+  when: varnish_use_packagecloud
 
 - name: Refresh yum metadata cache if repo changed.
   command: >


### PR DESCRIPTION
This could be useful if the package for the version/distro you need isn't present on packagecloud.io but it is present on the default repositories.

For example I need to install Varnish 5.x on Ubuntu 18.04. Packagecloud.io does not have bionic package for any 5.x package (only for 6.x). But on the default Ubuntu repository there is Varnish 5.2: https://packages.ubuntu.com/bionic/varnish