### PR TITLE
Fixes #68: Also remove old unit file if it exists for RedHat

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -45,3 +45,9 @@
   yum:
     name: "{{ varnish_package_name }}"
     state: present
+
+- name: Ensure old role-managed Varnish systemd unit file is removed.
+  file:
+    path: /etc/systemd/system/varnish.service
+    state: absent
+  when: varnish_systemd_config_path != '/etc/systemd/system'


### PR DESCRIPTION
I had problem with unit file update and a result found a solution in setup-Debian file. Then I added the same code to setup-RedHat. Tested on CentOS 7. 