### PR TITLE
Small changes to disable packagecloud repo for native repo install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Services that will be started at boot and should be running after this role is c
 
 You can configure multiple backends (and direct traffic from multiple virtual hosts to different backends) using the `varnish_backends` and `varnish_vhosts` variables. If you only use one backend (defined via `varnish_default_backend_host` and `varnish_default_backend_port`), then you do not need to define these variables. Do not add a `www` to the `vhosts` keys; it is added automatically by the `default.vcl.j2` VCL template.
 
+    varnish_packagecloud_bypass: false
+
+To disable the inclusion of the Packagecloud repository beacause you want to use the internal repo installation file for some reason. A use case for this is when you have to use your own satellite servers or air gapped networks with local repositories.
+Default vaule is set to false.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,10 @@ varnish_yum_repo_baseurl: https://packagecloud.io/varnishcache/{{ varnish_packag
 # Only used on Debian / Ubuntu.
 varnish_apt_repo: deb https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main
 
+# Completely bypass Packagecloud repo and use the varnish in the default repositories
+
+varnish_packagecloud_bypass: false
+
 # Optionally define additional backends.
 # varnish_backends:
 #   apache:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
 - name: Set the packagecloud repository name based on the version.
   set_fact:
     varnish_packagecloud_repo: "varnish{{ varnish_version|replace('.', '') }}"
+  when: not varnish_packagecloud_bypass
 
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,6 +15,7 @@
   apt_repository:
     repo: "{{ varnish_apt_repo }}"
     state: present
+  when: not varnish_packagecloud_bypass
 
 - name: Ensure Varnish is installed.
   apt:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -23,13 +23,17 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     priority: "{{ varnish_packagecloud_repo_yum_repository_priority }}"
   register: varnish_packagecloud_repo_addition
+  when:
+    - not varnish_packagecloud_bypass
 
 - name: Refresh yum metadata cache if repo changed.
   command: >
     yum -q makecache -y --disablerepo='*' --enablerepo='varnishcache_{{ varnish_packagecloud_repo }}'
   args:
     warn: false
-  when: varnish_packagecloud_repo_addition.changed
+    when:
+      - varnish_packagecloud_repo_addition.changed
+      - not varnish_packagecloud_bypass
   tags: ['skip_ansible_lint']
 
 - name: Disable varnish AppStream in RHEL 8.
@@ -39,6 +43,7 @@
   when:
     - varnish_packagecloud_repo_addition.changed
     - ansible_distribution_major_version | int == 8
+    - not varnish_packagecloud_bypass
   tags: ['skip_ansible_lint']
 
 - name: Ensure Varnish is installed.


### PR DESCRIPTION
I was about to just write a simple varnish role, but I always check if there is an existing role from @geerlingguy because, well you know your stuff. Have a use case that needs varnish but with internal repos.