### PR TITLE
Add Systemd StartPre and StopPost into Systemd service template

### DIFF
--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -25,8 +25,14 @@ TasksMax=infinity
 # Maximum size of the corefile.
 LimitCORE=infinity
 
+{% if systemd_service_exec_start_pre is defined %}
+ExecStartPre={{ systemd_service_exec_start_pre }}
+{% endif -%}
 ExecStart=/usr/sbin/varnishd -a {{ varnish_listen_address }}:{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }} {{ varnishd_extra_options }}
 ExecReload=/usr/sbin/varnishreload
+{% if systemd_service_exec_stop_pre is defined %}
+ExecStopPost={{ systemd_service_exec_stop_pre }}
+{% endif %}
 
 Restart=on-failure
 

--- a/templates/varnish.service.j2
+++ b/templates/varnish.service.j2
@@ -30,8 +30,8 @@ ExecStartPre={{ systemd_service_exec_start_pre }}
 {% endif -%}
 ExecStart=/usr/sbin/varnishd -a {{ varnish_listen_address }}:{{ varnish_listen_port }} -T {{ varnish_admin_listen_host }}:{{ varnish_admin_listen_port }}{% if varnish_pidfile %} -P {{ varnish_pidfile }}{% endif %} -f {{ varnish_config_path }}/default.vcl -S {{ varnish_config_path }}/secret -s {{ varnish_storage }} {{ varnishd_extra_options }}
 ExecReload=/usr/sbin/varnishreload
-{% if systemd_service_exec_stop_pre is defined %}
-ExecStopPost={{ systemd_service_exec_stop_pre }}
+{% if systemd_service_exec_stop_post is defined %}
+ExecStopPost={{ systemd_service_exec_stop_post }}
 {% endif %}
 
 Restart=on-failure


### PR DESCRIPTION
We use your Ansible role to install Varnish. But we must have a systemd service file like that : 

```
$ sudo systemctl cat varnish
# /lib/systemd/system/varnish.service
[Unit]
Description=Varnish Cache, a high-performance HTTP accelerator
After=network-online.target

[Service]
Type=forking
KillMode=process

PIDFile=/run/varnishd.pid

# Maximum number of open files (for ulimit -n)
LimitNOFILE=131072

# Locked shared memory - should suffice to lock the shared memory log
# (varnishd -l argument)
# Default log size is 80MB vsl + 1M vsm + header -> 82MB
# unit is bytes
LimitMEMLOCK=85983232

# Enable this to avoid "fork failed" on reload.
TasksMax=infinity

# Maximum size of the corefile.
LimitCORE=infinity

ExecStartPre=-/bin/mount -t tmpfs tmpfs /var/lib/varnish -o size=512M
ExecStart=/usr/sbin/varnishd -a :80 -T 127.0.0.1:6082 -P /run/varnishd.pid -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,4G -t 0 -p http_req_hdr_len=16k
ExecReload=/usr/sbin/varnishreload
ExecStopPost=-/bin/umount /var/lib/varnish

Restart=on-failure

[Install]
WantedBy=multi-user.target
```