### PR TITLE
Fixes #109, Fixes #110, Fixes #111

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 varnish_package_name: "varnish"
+varnish_modules_package_name: ""
 varnish_version: "6.4"
 
 varnish_use_default_vcl: true
@@ -24,6 +25,9 @@ varnishd_extra_options: ""
 
 varnish_enabled_services:
   - varnish
+
+# Use Packagecloud repo instead of distribution default
+varnish_apt_use_packagecloud: true
 
 # Make sure Packagecloud repo is used on RHEL/CentOS.
 varnish_packagecloud_repo_yum_repository_priority: "1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Ensure Varnish config path exists.
   file:
-    path: "{{ varnish_config_path }}"
+    path: "{{ varnish_systemd_override_path }}"
     state: directory
     mode: 0755
 
@@ -30,10 +30,10 @@
     (ansible_os_family == 'Debian' and ansible_distribution_release != "xenial")
   notify: restart varnish
 
-- name: Copy Debian Jessie/Xenial specific Varnish configs (systemd).
+- name: Copy override for systemd unit.
   template:
     src: varnish.service.j2
-    dest: "{{ varnish_systemd_config_path }}/varnish.service"
+    dest: "{{ varnish_systemd_override_path }}/varnish.service"
     owner: root
     group: root
     mode: 0644

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,28 +1,31 @@
 ---
-- name: Ensure dependencies are present.
-  apt:
-    name:
-      - apt-transport-https
-      - gnupg2
-    state: present
+- name: Configure packagecloud.io repository
+  block:
+    - name: Ensure dependencies are present.
+      apt:
+        name:
+          - apt-transport-https
+          - gnupg2
+        state: present
 
-- name: Add packagecloud.io Varnish apt key.
-  apt_key:
-    url: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
-    state: present
+    - name: Add packagecloud.io Varnish apt key.
+      apt_key:
+        url: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
+        state: present
 
-- name: Add packagecloud.io Varnish apt repository.
-  apt_repository:
-    repo: "{{ varnish_apt_repo }}"
-    state: present
+    - name: Add packagecloud.io Varnish apt repository.
+      apt_repository:
+        repo: "{{ varnish_apt_repo }}"
+        state: present
+  when: varnish_apt_use_packagecloud
 
 - name: Ensure Varnish is installed.
   apt:
     name: "{{ varnish_package_name }}"
     state: present
 
-- name: Ensure old role-managed Varnish systemd unit file is removed.
-  file:
-    path: /etc/systemd/system/varnish.service
-    state: absent
-  when: varnish_systemd_config_path != '/etc/systemd/system'
+- name: Ensure Varnish VMODs are installed.
+  apt:
+    name: "{{ varnish_modules_package_name }}"
+    state: present
+  when: varnish_modules_package_name

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -41,3 +41,9 @@
   yum:
     name: "{{ varnish_package_name }}"
     state: present
+
+- name: Ensure Varnish VMODs are installed.
+  yum:
+    name: "{{ varnish_modules_package_name }}"
+    state: present
+  when: varnish_modules_package_name

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
 varnish_sysvinit_config_path: /etc/default
-varnish_systemd_config_path: /lib/systemd/system
+varnish_systemd_override_path: /etc/systemd/system

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,3 @@
 ---
 varnish_sysvinit_config_path: /etc/sysconfig
-varnish_systemd_config_path: /usr/lib/systemd/system
+varnish_systemd_override_path: /etc/systemd/system


### PR DESCRIPTION
- Support both vendor and distribution packages for Debian, depending on "varnish_apt_use_packagecloud" (#109)
- Install systemd unit in /etc/systemd/system for compatiblity after package updates (#110)
- Support installation of additional module package, e.g. for Debian "varnish-modules" (#111)